### PR TITLE
Support special characters in POSTGRES_URI

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -6,7 +6,7 @@ from celery import Celery
 import psycopg2
 
 
-POSTGRES_URI = urlparse.urlparse(os.environ["POSTGRES_URI"])
+POSTGRES_URI = urlparse.urlparse(urlparse.unquote(os.environ["POSTGRES_URI"]))
 POSTGRES_USER = POSTGRES_URI.username
 POSTGRES_PASSWORD = POSTGRES_URI.password
 POSTGRES_HOST = POSTGRES_URI.hostname


### PR DESCRIPTION
In case a special character is URL encoded in any part of the POSTGRES_URI, it currently results being
 passed verbatim to Postgres leading to authentication errors.
This commit fixes this issue by decoding the URI string before parsing (which the urlparse function does not do).